### PR TITLE
Updated dependency path for normalize & bootstrap to work with webpack

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -1,7 +1,7 @@
 // ==========================================================================
 // Mixins
 // ==========================================================================
-@import (multiple, less) "bootstrap/less/mixins.less";
+@import (multiple, less) "~bootstrap/less/mixins.less";
 
 // Global mixins file, all global helper mixins should go into this file
 

--- a/less/reset.less
+++ b/less/reset.less
@@ -26,5 +26,5 @@
 		outline-offset: -2px;
 	}
 
-	@import (less) 'normalize-css/normalize.css';
+	@import (less) '~normalize-css/normalize.css';
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "less-helpers",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A set of basic reuseable less components",
   "keywords": [
     "less",


### PR DESCRIPTION
Updating this so that legacy projects that use this repo will work with webpack.
